### PR TITLE
Fix: Docker Hub Rate Limit - Use ECR Public Gallery

### DIFF
--- a/DOCKER_RATE_LIMIT_FIX.md
+++ b/DOCKER_RATE_LIMIT_FIX.md
@@ -1,0 +1,33 @@
+# Docker Hub Rate Limit 修正
+
+## 🚨 問題
+CodeBuildでDocker Hub Rate Limitエラーが発生
+
+```
+429 Too Many Requests - Server message: toomanyrequests: 
+You have reached your unauthenticated pull rate limit.
+```
+
+## 🔧 解決方法
+Docker HubからAmazon ECR Public Galleryに変更
+
+### 変更内容
+```dockerfile
+# 変更前
+FROM python:3.9-slim
+
+# 変更後  
+FROM public.ecr.aws/docker/library/python:3.9-slim
+```
+
+## 📋 修正詳細
+- **修正日時**: 2025-08-02 14:41:38 JST
+- **対象ファイル**: `Dockerfile`
+- **変更理由**: Docker Hub匿名プル制限回避
+- **期待結果**: CodeBuildでのDockerイメージビルド成功
+
+## 🎯 テスト予定
+1. PRマージ後のCodePipeline自動実行
+2. Dockerイメージビルド成功確認
+3. ECRプッシュ成功確認
+4. ECSデプロイ成功確認

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM public.ecr.aws/docker/library/python:3.9-slim
 
 # 作業ディレクトリの設定
 WORKDIR /app


### PR DESCRIPTION
- 問題: Docker Hub 429 Too Many Requests エラー
- 解決: python:3.9-slim → public.ecr.aws/docker/library/python:3.9-slim
- 目的: CodeBuildでのDockerイメージビルド成功
- テストID: fix-docker-rate-limit-1754113298