### PR TITLE
Fix corrupted WordPress blog workflow file

### DIFF
--- a/.github/workflows/update-blog.yml
+++ b/.github/workflows/update-blog.yml
@@ -1,3 +1,131 @@
+name: Update WordPress Blog
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:  # 手動実行用
+
+jobs:
+  update-blog:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.9'
+        
+    - name: Install dependencies
+      run: |
+        pip install requests
+        
+    - name: Create blog post content
+      id: create-content
+      run: |
+        # 引継ぎ文書の内容を作成（テスト用）
+        cat << 'EOF' > blog_content.md
+        # 開発作業完了報告
+        
+        ## 作業概要
+        Sales Tools API統合プロジェクトの開発作業が完了しました。
+        
+        ## 実装内容
+        - AWS Lambda関数の実装
+        - CodePipelineによるCI/CD構築  
+        - GitHub Actionsとの連携
+        - WordPress REST API連携機能
+        
+        ## 技術スタック
+        - Python 3.9
+        - AWS Lambda
+        - AWS CodePipeline
+        - GitHub Actions
+        - WordPress REST API
+        
+        ## 成果物
+        - Lambda関数: 商品価格分析機能
+        - CI/CDパイプライン: 自動デプロイ環境
+        - API連携: 外部サービスとの統合
+        
+        ## 今後の課題
+        - パフォーマンス最適化
+        - エラーハンドリング強化
+        - モニタリング機能追加
+        
+        ## 引継ぎ事項
+        - 定期的なAPI制限確認が必要
+        - ログ監視の継続実施
+        - セキュリティアップデート対応
+        EOF
+        
+    - name: Sanitize content for blog
+      id: sanitize
+      run: |
+        # 秘匿化処理
+        python3 << 'EOF'
+        import re
+        
+        # blog_content.mdを読み込み
+        with open('blog_content.md', 'r', encoding='utf-8') as f:
+            content = f.read()
+        
+        # 秘匿化処理
+        sanitized_content = content
+        
+        # APIキー関連
+        sanitized_content = re.sub(r'SALES_TOOLS_API_KEY[_A-Z]*', '[APIキー]', sanitized_content)
+        
+        # URL関連
+        sanitized_content = re.sub(r'https://hack-note\.com', '[サイトURL]', sanitized_content)
+        sanitized_content = re.sub(r'hack-note\.com', '[サイトドメイン]', sanitized_content)
+        
+        # AWS リソース名
+        sanitized_content = re.sub(r'sales-tools-api-stack', '[CloudFormationスタック]', sanitized_content)
+        
+        # GitHub関連
+        sanitized_content = re.sub(r'keepa_work', '[プロジェクト名]', sanitized_content)
+        
+        # ファイルパス
+        sanitized_content = re.sub(r'/mnt/c/Users/[^/]+/', '[ローカルパス]/', sanitized_content)
+        
+        print("秘匿化処理完了")
+        print("=" * 50)
+        print(sanitized_content)
+        print("=" * 50)
+        
+        # 秘匿化済みコンテンツを保存
+        with open('sanitized_content.md', 'w', encoding='utf-8') as f:
+            f.write(sanitized_content)
+        EOF
+        
+    - name: Post to WordPress
+      env:
+        WORDPRESS_URL: ${{ secrets.WORDPRESS_URL }}
+        WORDPRESS_USERNAME: ${{ secrets.WORDPRESS_USERNAME }}
+        WORDPRESS_APP_PASSWORD: ${{ secrets.WORDPRESS_APP_PASSWORD }}
+      run: |
+        python3 << 'EOF'
+        import requests
+        import json
+        import os
+        from datetime import datetime
+        
+        # 環境変数取得
+        wp_url = os.environ.get('WORDPRESS_URL', 'https://hack-note.com')
+        wp_user = os.environ.get('WORDPRESS_USERNAME')
+        wp_pass = os.environ.get('WORDPRESS_APP_PASSWORD')
+        
+        if not wp_user or not wp_pass:
+            print("WordPress認証情報が設定されていません")
+            exit(1)
+        
+        # 秘匿化済みコンテンツ読み込み
+        with open('sanitized_content.md', 'r', encoding='utf-8') as f:
+            content = f.read()
+        
         # 投稿データ作成（tagsを削除してシンプルに）
         post_data = {
             'title': f'開発作業完了報告 - {datetime.now().strftime("%Y/%m/%d")}',
@@ -5,3 +133,29 @@
             'status': 'draft',  # 下書き保存
             'categories': [1]   # 開発ログカテゴリ（デフォルトカテゴリ）
         }
+        
+        # WordPress REST API呼び出し
+        api_url = f'{wp_url}/wp-json/wp/v2/posts'
+        
+        try:
+            response = requests.post(
+                api_url,
+                json=post_data,
+                auth=(wp_user, wp_pass),
+                headers={'Content-Type': 'application/json'}
+            )
+            
+            if response.status_code == 201:
+                result = response.json()
+                print(f"✅ Blog投稿成功!")
+                print(f"投稿ID: {result['id']}")
+                print(f"タイトル: {result['title']['rendered']}")
+                print(f"ステータス: {result['status']}")
+                print(f"編集URL: {wp_url}/wp-admin/post.php?post={result['id']}&action=edit")
+            else:
+                print(f"❌ Blog投稿失敗: {response.status_code}")
+                print(f"エラー内容: {response.text}")
+                
+        except Exception as e:
+            print(f"❌ 投稿処理でエラー: {str(e)}")
+        EOF


### PR DESCRIPTION
## 🚨 問題
前回のstr_replace操作でワークフローファイルが破損し、GitHub Actionsが実行できない状態

## 🔧 修正内容
- **完全なワークフローファイル再作成**: 破損したYAML構造を修復
- **全ステップ復元**: checkout, python setup, content creation, sanitization, WordPress投稿
- **YAML構文修正**: 正しいインデントと構造に修正
- **GitHub Actions形式準拠**: workflow_dispatch対応

## ✅ 期待される動作
- PRマージ後にGitHub Actionsが正常実行
- WordPress REST APIでblog投稿成功
- 引継ぎ文書の下書き保存

## 📋 修正ファイル
- `.github/workflows/update-blog.yml`: 完全再作成